### PR TITLE
Being able to set the page source manually.

### DIFF
--- a/SimpleBrowser.WebDriver/BrowserWrapper.cs
+++ b/SimpleBrowser.WebDriver/BrowserWrapper.cs
@@ -25,6 +25,7 @@ namespace SimpleBrowser.WebDriver
 		public string CurrentHtml
 		{
 			get { return _my.CurrentHtml; }
+			set { _my.SetContent(value); }
 		}
 
 		public IHtmlResult Find(string query, object param)

--- a/SimpleBrowser.WebDriver/IBrowser.cs
+++ b/SimpleBrowser.WebDriver/IBrowser.cs
@@ -11,7 +11,7 @@ namespace SimpleBrowser.WebDriver
 	/// </summary>
 	public interface IBrowser
 	{
-		string CurrentHtml { get; }
+		string CurrentHtml { get; set; }
 		Uri Url { get; }
 		KeyStateOption KeyState { get; set; }
 		IHtmlResult Find(string query, object param);

--- a/SimpleBrowser.WebDriver/SimpleBrowserDriver.cs
+++ b/SimpleBrowser.WebDriver/SimpleBrowserDriver.cs
@@ -47,7 +47,7 @@ namespace SimpleBrowser.WebDriver
 		public string PageSource
 		{
 			get { return _my.CurrentHtml; }
-			set { }
+			set { _my.CurrentHtml = value; }
 		}
 
 		public void Quit()


### PR DESCRIPTION
To make it easier to write code for scraping a website that contains multiple web accesses, it can be handy to save the html so far to disk to keep down the number of web accesses.
